### PR TITLE
fix: workspace package conditions

### DIFF
--- a/packages/vike-cloudflare/src/index.ts
+++ b/packages/vike-cloudflare/src/index.ts
@@ -79,7 +79,8 @@ export const pages = (options?: VikeCloudflarePagesOptions): Plugin => {
           },
         },
         resolve: {
-          conditions: ["edge-light", "worker", "browser", "module", "import", "require"],
+          // https://github.com/cloudflare/workers-sdk/blob/515de6ab40ed6154a2e6579ff90b14b304809609/packages/wrangler/src/deployment-bundle/bundle.ts#L37
+          conditions: ["workerd", "worker", "browser", "module", "import", "require"],
         },
       };
     },


### PR DESCRIPTION
Vite bundles/inlines workspace packages by default.
It needs to bundle the right exports.

Without PR, packages in a monorepo that are linked are bundled with possibly node-only exports.
This is also an issue if something/someone sets a package as noExternal, the PR fixes that too.

